### PR TITLE
Fixes #2

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ The # Intel Developer Cloud (IDC) # is a cloud-based platform that provides deve
 
 In this setup, you would develop your LLM chatbot application, then deploy it on the IDC. This allows you to take full advantage of the capabilities of these processors and the flexibility and scalability of cloud computing.
 
+For video step through guide please [refer to this YoutTube video](https://www.youtube.com/watch?v=K4nl33oL_n8).
+
 Steps to execute:
 
 # a. Register in Intel Developer Cloud

--- a/README.md
+++ b/README.md
@@ -73,24 +73,23 @@ Steps to execute:
 
     ngrok config add-authtoken <authtoken>
 
-    Example :
+  Example :
 
-    ngrok config add-authtoken 219XW8KAr0Dbi5PVkTlS4HUkM5B_77YQKUJ7e1AgtThaEBYPo
-
-    Please note that the authtoken provided in the command is just an example and should be replaced with your actual ngrok authtoken. 
-    You canfind your authtoken in your ngrok dashboard after signing in to your account.
+  `ngrok config add-authtoken 219XW8KAr0Dbi5PVkTlS4HUkM5B_77YQKUJ7e1AgtThaEBYPo`
+  Please note that the authtoken provided in the command is just an example and should be replaced with your actual ngrok authtoken. 
+  You canfind your authtoken in your ngrok dashboard after signing in to your account.
 
   ## 6. Open another terminal 
   
-    Use the following command 
+  Use the following command 
 
     ngrok http 7860 
 
-    The command `ngrok http 7860` is used to expose a local web server to the internet. Here's what each part of the command does:
+  The command `ngrok http 7860` is used to expose a local web server to the internet. Here's what each part of the command does:
 
-    `7860`: This is the port number on your local machine that `ngrok` will expose to the internet. In this case, `ngrok` will tunnel       
-     traffic from the public internet to your local machine's port 7860.
+  `7860`: This is the port number on your local machine that `ngrok` will expose to the internet. In this case, `ngrok` will tunnel       
+  traffic from the public internet to your local machine's port 7860.
 
-    When you run this command, `ngrok` will provide a public URL (like `http://<random-subdomain>.ngrok.io`) that you can use to access 
-    your local web server from anywhere on the internet. Any HTTP requests made to this public URL will be forwarded to your local 
-    machine on port 7860.
+  When you run this command, `ngrok` will provide a public URL (like `http://<random-subdomain>.ngrok.io`) that you can use to access 
+  your local web server from anywhere on the internet. Any HTTP requests made to this public URL will be forwarded to your local 
+  machine on port 7860.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ Steps to execute:
 
   ## 2. Install the dependencies and library packages required to run the application
 
-  Command:  pip install huggingface_hub gradio 
+  Command:
+  
+     pip install huggingface_hub gradio 
 
   ## 3. Open a .py file and copy the code or upload the .py file
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Steps to execute:
   6.Enter your Intel Developer Cloud code provided to setup a bare metal server instance.
 
 # b. Setup an instance 
-  # 1.Setup a conda environment after you access the instance 
+  ## 1. Setup a conda environment after you access the instance 
 
     mkdir -p ~/miniconda3
     wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda3/miniconda.sh
@@ -29,16 +29,16 @@ Steps to execute:
 
     ~/miniconda3/bin/conda init bash
 
-  # 2.Install the dependencies and library packages required to run the application
+  ## 2. Install the dependencies and library packages required to run the application
 
   Command:  pip install huggingface_hub gradio 
 
-  # 3. Open a .py file and copy the code or upload the .py file
+  ## 3. Open a .py file and copy the code or upload the .py file
 
-  # 4. Use the following command below :
+  ## 4. Use the following command below :
 
-  curl -s https://ngrok-agent.s3.amazonaws.com/ngrok.asc | sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null && echo "deb https://ngrok- 
-  agent.s3.amazonaws.com buster main" | sudo tee /etc/apt/sources.list.d/ngrok.list && sudo apt update && sudo apt install ngrok
+    curl -s https://ngrok-agent.s3.amazonaws.com/ngrok.asc | sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null && echo \
+    "deb https://ngrok-agent.s3.amazonaws.com buster main" | sudo tee /etc/apt/sources.list.d/ngrok.list && sudo apt update && sudo apt install ngrok
 
   This command is a one-liner that installs `ngrok` on a Linux system. It's a sequence of commands combined using `&&` operator, which means 
   the next command will only run if the previous command succeeds. Let's break it down:
@@ -67,7 +67,7 @@ Steps to execute:
    In summary, this command sequence is adding the ngrok repository to your system's package manager, updating the package list, and then 
    installing ngrok.
 
-  # 5.Use the following command:
+  ## 5. Use the following command:
 
     ngrok config add-authtoken <authtoken>
 
@@ -78,7 +78,7 @@ Steps to execute:
     Please note that the authtoken provided in the command is just an example and should be replaced with your actual ngrok authtoken. 
     You canfind your authtoken in your ngrok dashboard after signing in to your account.
 
-  # 6. Open another terminal 
+  ## 6. Open another terminal 
   
     Use the following command 
 
@@ -92,10 +92,3 @@ Steps to execute:
     When you run this command, `ngrok` will provide a public URL (like `http://<random-subdomain>.ngrok.io`) that you can use to access 
     your local web server from anywhere on the internet. Any HTTP requests made to this public URL will be forwarded to your local 
     machine on port 7860.
-
-    
-
-
-
-
-


### PR DESCRIPTION
Avoid space in the middle of the second URL of the ngrok install complex command.
+ numbered steps are Markdown subtitles, because a. and b. are titles.